### PR TITLE
feat: 大規模機能追加 - SQL/DB管理、診断改善、共有設定、削除オプション等

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -421,12 +421,17 @@ function spawnServerProcess(serverId, opts) {
   const memStr = jvmMemory ? `${jvmMemory.value}${jvmMemory.unit}` : '2G'
   const jar = serverType === 'paper' ? 'paper.jar' : 'fabric-server-launch.jar'
   // UTF-8フラグでログ文字化けを防止
+  // JAVA_TOOL_OPTIONS は shell を介さない場合でも確実に UTF-8 を適用
+  const javaEnv = {
+    ...process.env,
+    JAVA_TOOL_OPTIONS: '-Dfile.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dconsole.encoding=UTF-8',
+  }
   const proc = spawn(javaBin, [
     '-Dfile.encoding=UTF-8',
     '-Dstdout.encoding=UTF-8',
     '-Dconsole.encoding=UTF-8',
     `-Xms${memStr}`, `-Xmx${memStr}`, '-jar', jar, 'nogui'
-  ], { cwd: serverDir, shell: !javaPath })
+  ], { cwd: serverDir, shell: !javaPath, env: javaEnv })
   processes[serverId] = proc
   const pids = loadPids()
   pids[serverId] = proc.pid
@@ -475,6 +480,13 @@ app.whenReady().then(() => {
   ipcMain.handle('delete-server-dir', (_, { serverDir }) => {
     if (serverDir && existsSync(serverDir)) {
       rmSync(serverDir, { recursive: true, force: true })
+    }
+    return true
+  })
+
+  ipcMain.handle('delete-cluster-dir', (_, { clusterDir }) => {
+    if (clusterDir && existsSync(clusterDir)) {
+      rmSync(clusterDir, { recursive: true, force: true })
     }
     return true
   })
@@ -879,7 +891,10 @@ app.whenReady().then(() => {
       })
       const type = detectServerType(serverDir)
       const mcVersion = type === 'fabric' ? detectFabricMcVersion(serverDir) : detectPaperMcVersion(serverDir)
-      servers.push({ name: entry.name, port: parseInt(props['server-port']) || 25565, serverDir, type, mcVersion })
+      const levelName = props['level-name'] || 'world'
+      // level-name がデフォルト（"world"）以外ならそれをサーバー名として使用
+      const name = (levelName && levelName !== 'world') ? levelName : entry.name
+      servers.push({ name, port: parseInt(props['server-port']) || 25565, serverDir, type, mcVersion, levelName })
     }
     let velocityConfig = null
     const velocityDir = join(clusterDir, 'velocity')
@@ -915,10 +930,13 @@ app.whenReady().then(() => {
       props[key.trim()] = rest.join('=').trim()
     })
     const port = parseInt(props['server-port']) || 25565
-    const name = serverDir.split(/[\\/]/).pop()
+    const dirName = serverDir.split(/[\\/]/).pop()
+    const levelName = props['level-name'] || 'world'
+    // level-name がデフォルト（"world"）以外ならそれをサーバー名として使用
+    const name = (levelName && levelName !== 'world') ? levelName : dirName
     const type = detectServerType(serverDir)
     const mcVersion = type === 'fabric' ? detectFabricMcVersion(serverDir) : detectPaperMcVersion(serverDir)
-    return { success: true, name, port, serverDir, type, mcVersion }
+    return { success: true, name, port, serverDir, type, mcVersion, levelName }
   })
 
   ipcMain.handle('start-velocity', (_, { clusterId, velocityDir }) => {
@@ -1039,6 +1057,54 @@ app.whenReady().then(() => {
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+
+  // ─── DB 自動起動 ─────────────────────────────────────────────────────────
+  // アプリ起動時にDBがインストール済みなら自動起動する
+  const settingsOnStart = loadSettings()
+  if (settingsOnStart.db && settingsOnStart.db.installed && settingsOnStart.db.binDir) {
+    const autoStartDb = async () => {
+      try {
+        const binDir = settingsOnStart.db.binDir
+        const exe = join(binDir, 'mysqld.exe')
+        if (!existsSync(exe)) return
+        const dataDir = settingsOnStart.db.dataDir
+        const port = settingsOnStart.db.port || 3306
+        const proc = spawn(exe, [
+          `--datadir=${dataDir}`,
+          `--port=${port}`,
+          '--bind-address=127.0.0.1',
+          '--console',
+        ], { cwd: binDir })
+        proc.stdout?.setEncoding('utf8')
+        proc.stderr?.setEncoding('utf8')
+        const checkReady = (data) => {
+          if (data && data.includes('ready for connections')) {
+            dbProcess = proc
+            mainWindow?.webContents.send('db-status-changed', { running: true })
+          }
+        }
+        proc.stdout?.on('data', checkReady)
+        proc.stderr?.on('data', checkReady)
+        proc.on('close', () => {
+          if (dbProcess === proc) {
+            dbProcess = null
+            mainWindow?.webContents.send('db-status-changed', { running: false })
+          }
+        })
+        // 15秒タイムアウトで強制的にrunningとマーク（起動済みの場合）
+        setTimeout(() => {
+          if (!dbProcess && proc && !proc.killed) {
+            dbProcess = proc
+            mainWindow?.webContents.send('db-status-changed', { running: true })
+          }
+        }, 15000)
+      } catch { /* 自動起動失敗は無視 */ }
+    }
+    // ウィンドウが準備できてから起動
+    mainWindow.once('ready-to-show', () => {
+      setTimeout(autoStartDb, 1000)
+    })
+  }
 
   // ウィンドウ表示後に更新チェック（開発環境では無効）
   if (!is.dev) {
@@ -1865,6 +1931,52 @@ ipcMain.handle('repair-required-mods', async (_, { serverDir, mcVersion, forward
   return { success: true, repaired: results }
 })
 
+// Invsync の利用可能バージョン一覧取得（GitHub Releases）
+ipcMain.handle('invsync-list-versions', async () => {
+  try {
+    const { net } = await import('electron')
+    const fetchJson = (url) => new Promise((resolve, reject) => {
+      const req = net.request({ url, headers: { 'User-Agent': 'nexus-mc/1.0' } })
+      let d = ''; req.on('response', r => { r.on('data', c => { d += c }); r.on('end', () => { try { resolve(JSON.parse(d)) } catch (e) { reject(e) } }) }); req.on('error', reject); req.end()
+    })
+    const releases = await fetchJson('https://api.github.com/repos/Simohayhe/Invsyncmod/releases')
+    return (releases || []).map(r => ({
+      tag: r.tag_name,
+      // タグ名から MC バージョンを推定（例: v1.21.11 → 1.21.11）
+      mcVersion: r.tag_name.replace(/^v/, ''),
+      downloadUrl: (r.assets || []).find(a => a.name.endsWith('.jar'))?.browser_download_url || null,
+      fileName: (r.assets || []).find(a => a.name.endsWith('.jar'))?.name || null,
+    })).filter(r => r.downloadUrl)
+  } catch { return [] }
+})
+
+// Invsync を指定サーバーにインストール
+ipcMain.handle('invsync-install', async (_, { serverDir, downloadUrl, fileName }) => {
+  try {
+    const { net } = await import('electron')
+    const fs = require('fs')
+    const modsDir = join(serverDir, 'mods')
+    if (!existsSync(modsDir)) mkdirSync(modsDir, { recursive: true })
+    // 既存の Invsync jar を削除
+    const existing = readdirSync(modsDir).filter(f => f.toLowerCase().includes('invsync'))
+    for (const f of existing) unlinkSync(join(modsDir, f))
+    const destPath = join(modsDir, fileName)
+    await new Promise((resolve, reject) => {
+      const req = net.request(downloadUrl)
+      req.on('response', r => { const file = fs.createWriteStream(destPath); r.on('data', c => file.write(c)); r.on('end', () => { file.close(); resolve() }) }); req.on('error', reject); req.end()
+    })
+    return { success: true }
+  } catch (e) { return { success: false, error: e.message } }
+})
+
+// Invsync インストール状況チェック
+ipcMain.handle('invsync-check', (_, { serverDir }) => {
+  const modsDir = join(serverDir, 'mods')
+  if (!existsSync(modsDir)) return { installed: false, fileName: null }
+  const found = readdirSync(modsDir).find(f => f.toLowerCase().includes('invsync') && f.endsWith('.jar'))
+  return { installed: !!found, fileName: found || null }
+})
+
 // apply-server-mods: 必須Modはlibrary管理外でも削除しない
 // ─── ライブラリフォルダ自動生成 ─────────────────────────────────────────────────
 
@@ -1965,6 +2077,28 @@ ipcMain.handle('diag-check-port-external', async (_, { port }) => {
     })
     req.on('error', (e) => resolve({ success: false, error: e.message }))
     req.setTimeout(20000)
+    req.end()
+  })
+})
+
+// インターネット速度計測（Cloudflare 10MB ファイルDL）
+ipcMain.handle('check-internet-speed', async () => {
+  const { net } = await import('electron')
+  return new Promise((resolve) => {
+    const url = 'https://speed.cloudflare.com/__down?bytes=10000000'
+    const req = net.request(url)
+    let bytes = 0
+    const startTime = Date.now()
+    req.on('response', r => {
+      r.on('data', chunk => { bytes += chunk.length })
+      r.on('end', () => {
+        const elapsed = (Date.now() - startTime) / 1000
+        const mbps = (bytes * 8 / 1_000_000 / elapsed).toFixed(1)
+        resolve({ success: true, mbps: parseFloat(mbps), bytes, elapsed: elapsed.toFixed(2) })
+      })
+    })
+    req.on('error', e => resolve({ success: false, error: e.message }))
+    req.setTimeout(30000)
     req.end()
   })
 })
@@ -2413,36 +2547,44 @@ ipcMain.handle('db-get-settings', () => {
   return settings.db || null
 })
 
-// ─── 終了ブロック: DBが動いていてサーバーが起動中なら終了を阻止 ───────────────
+// ─── 終了ブロック: DBが動いていてクラスターサーバーが起動中なら終了を阻止 ──────
 app.on('before-quit', (event) => {
-  if (!dbProcess) return
   const runningServerIds = Object.keys(processes).filter(k => !k.startsWith('velocity-'))
-  if (runningServerIds.length === 0) {
-    // DBを先に停止してから終了
-    if (dbProcess) {
-      try { dbProcess.kill() } catch { /* ignore */ }
-      dbProcess = null
+
+  // DB が動いていてクラスター配下のサーバーが起動中なら終了を阻止
+  if (dbProcess && runningServerIds.length > 0) {
+    const data = loadData()
+    // クラスター配下のサーバーのみを対象にする（SQL使用サーバー）
+    const runningClusterServers = []
+    for (const id of runningServerIds) {
+      for (const cluster of data.clusters || []) {
+        const srv = (cluster.servers || []).find(s => s.id === id)
+        if (srv) {
+          runningClusterServers.push({ clusterName: cluster.name, serverName: srv.name })
+          break
+        }
+      }
     }
-    return
+    if (runningClusterServers.length > 0) {
+      event.preventDefault()
+      const detail = runningClusterServers
+        .map(({ clusterName, serverName }) => `・クラスター「${clusterName}」のサーバー「${serverName}」`)
+        .join('\n')
+      dialog.showMessageBox(mainWindow, {
+        type: 'warning',
+        buttons: ['OK'],
+        title: '終了できません',
+        message: 'DBを使用しているサーバーが起動中のため終了できません。\nサーバーを停止してからアプリを終了してください。',
+        detail
+      })
+      return
+    }
   }
-  event.preventDefault()
-  const data = loadData()
-  const names = runningServerIds.map(id => {
-    for (const cluster of data.clusters || []) {
-      const srv = (cluster.servers || []).find(s => s.id === id)
-      if (srv) return `${cluster.name} > ${srv.name}`
-    }
-    for (const sv of data.standalone || []) {
-      if (sv.id === id) return sv.name
-    }
-    return id
-  })
-  dialog.showMessageBox(mainWindow, {
-    type: 'warning',
-    buttons: ['OK'],
-    title: '終了できません',
-    message: '起動中のサーバーがあるため終了できません',
-    detail: names.map(n => `・${n}`).join('\n')
-  })
+
+  // DBを停止してから終了
+  if (dbProcess) {
+    try { dbProcess.kill() } catch { /* ignore */ }
+    dbProcess = null
+  }
 })
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -19,6 +19,7 @@ const api = {
   onServerStopped: (serverId, cb) => { const h = () => cb(); ipcRenderer.on(`stopped-${serverId}`, h); return () => ipcRenderer.removeListener(`stopped-${serverId}`, h) },
   removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
   deleteServerDir: (opts) => ipcRenderer.invoke('delete-server-dir', opts),
+  deleteClusterDir: (opts) => ipcRenderer.invoke('delete-cluster-dir', opts),
   createClusterDir: (opts) => ipcRenderer.invoke('create-cluster-dir', opts),
   installVelocity: (opts) => ipcRenderer.invoke('install-velocity', opts),
   onVelocityLog: (cb) => { const h = (_, msg) => cb(msg); ipcRenderer.on('velocity-log', h); return () => ipcRenderer.removeListener('velocity-log', h) },
@@ -100,12 +101,19 @@ const api = {
   diagUpnpClosePort: (opts) => ipcRenderer.invoke('diag-upnp-close-port', opts),
   diagUpnpListMapped: () => ipcRenderer.invoke('diag-upnp-list-mapped'),
   diagUpnpCheck: () => ipcRenderer.invoke('diag-upnp-check'),
+  diagCheckPortExternal: (opts) => ipcRenderer.invoke('diag-check-port-external', opts),
+  checkInternetSpeed: () => ipcRenderer.invoke('check-internet-speed'),
   getAllServerPorts: () => ipcRenderer.invoke('get-all-server-ports'),
 
   // ─── 必須Mod / ライブラリ ───────────────────────────────────────────────
   checkRequiredMods: (opts) => ipcRenderer.invoke('check-required-mods', opts),
   repairRequiredMods: (opts) => ipcRenderer.invoke('repair-required-mods', opts),
   ensureModSourceFolder: (opts) => ipcRenderer.invoke('ensure-mod-source-folder', opts),
+
+  // ─── Invsync ─────────────────────────────────────────────────────────────
+  invsyncListVersions: () => ipcRenderer.invoke('invsync-list-versions'),
+  invsyncInstall: (opts) => ipcRenderer.invoke('invsync-install', opts),
+  invsyncCheck: (opts) => ipcRenderer.invoke('invsync-check', opts),
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/components/Diagnostics.jsx
+++ b/src/renderer/src/components/Diagnostics.jsx
@@ -7,7 +7,7 @@ function Signal({ status, label, children }) {
     [STATUS.IDLE]:    { bg: 'var(--bg-section)', dot: '#6b7280', border: 'var(--border)' },
     [STATUS.OK]:      { bg: 'rgba(34,197,94,0.08)',  dot: '#22c55e', border: 'rgba(34,197,94,0.3)' },
     [STATUS.WARN]:    { bg: 'rgba(234,179,8,0.08)',  dot: '#eab308', border: 'rgba(234,179,8,0.3)' },
-    [STATUS.ERROR]:   { bg: 'rgba(239,68,68,0.08)',  dot: '#ef4444', border: 'rgba(239,68,68,0.3)' },
+    [STATUS.ERROR]:   { bg: 'rgba(239,68,68,0.1)',   dot: '#ef4444', border: 'rgba(239,68,68,0.35)' },
     [STATUS.LOADING]: { bg: 'rgba(65,90,200,0.06)',  dot: 'var(--text-accent)', border: 'var(--border-strong)' },
   }
   const c = colors[status] || colors[STATUS.IDLE]
@@ -15,7 +15,7 @@ function Signal({ status, label, children }) {
     <div className="diag-signal-row" style={{ background: c.bg, borderColor: c.border }}>
       <span className="diag-signal-dot" style={{ background: c.dot, boxShadow: `0 0 6px ${c.dot}` }}
         data-loading={status === STATUS.LOADING ? 'true' : undefined} />
-      <span className="diag-signal-label">{label}</span>
+      <span className="diag-signal-label" style={{ color: status === STATUS.ERROR ? '#ef4444' : undefined }}>{label}</span>
       {children}
     </div>
   )
@@ -27,27 +27,205 @@ function CopyBtn({ text }) {
   return <button className="diag-copy-btn" onClick={copy}>{copied ? '✓' : 'コピー'}</button>
 }
 
+// ─── ポート開放チェックセクション ────────────────────────────────────────────
+function PortCheckSection({ globalIp, allPorts }) {
+  const [ip, setIp] = useState('')
+  const [portMode, setPortMode] = useState('custom') // 'custom' | serverId
+  const [customPort, setCustomPort] = useState('')
+  const [checking, setChecking] = useState(false)
+  const [result, setResult] = useState(null) // { reachable, ip, port } | { error }
+
+  useEffect(() => {
+    if (globalIp && globalIp !== '取得中...' && globalIp !== '取得失敗') {
+      setIp(globalIp)
+    }
+  }, [globalIp])
+
+  // フラットなポート一覧
+  const flatPorts = []
+  for (const c of allPorts?.clusters || []) {
+    if (c.velocityPort) flatPorts.push({ id: `vel-${c.id}`, label: `${c.name} (Velocity)`, port: c.velocityPort })
+    for (const s of c.servers || []) {
+      if (s.port) flatPorts.push({ id: s.id, label: `${c.name} > ${s.name}`, port: s.port })
+    }
+  }
+  for (const s of allPorts?.standalone || []) {
+    if (s.port) flatPorts.push({ id: s.id, label: s.name, port: s.port })
+  }
+
+  const resolvedPort = portMode === 'custom'
+    ? parseInt(customPort) || null
+    : flatPorts.find(p => p.id === portMode)?.port || null
+
+  const resetIp = async () => {
+    setIp('取得中...')
+    const gip = await window.api.fetchGlobalIp()
+    setIp(gip)
+  }
+
+  const checkPort = async () => {
+    if (!resolvedPort || !ip.trim()) return
+    setChecking(true)
+    setResult(null)
+    const res = await window.api.diagCheckPortExternal({ port: resolvedPort })
+    setResult(res)
+    setChecking(false)
+  }
+
+  return (
+    <div className="diag-card">
+      <div className="diag-card-title">🔌 ポート開放チェック</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {/* IP 入力 */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 70 }}>IPアドレス</span>
+          <input
+            className="modal-input"
+            style={{ flex: 1 }}
+            value={ip}
+            onChange={e => setIp(e.target.value)}
+            placeholder="グローバルIPアドレス"
+          />
+          <button className="btn btn-restart" style={{ fontSize: 12, whiteSpace: 'nowrap' }} onClick={resetIp}>
+            デフォルトに戻す
+          </button>
+        </div>
+
+        {/* ポート選択 */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 70 }}>ポート</span>
+          <select
+            className="modal-input"
+            style={{ flex: 1 }}
+            value={portMode}
+            onChange={e => setPortMode(e.target.value)}
+          >
+            <option value="custom">手動入力</option>
+            {flatPorts.map(p => (
+              <option key={p.id} value={p.id}>{p.label} ({p.port})</option>
+            ))}
+          </select>
+          {portMode === 'custom' && (
+            <input
+              className="modal-input"
+              style={{ width: 100 }}
+              type="number"
+              value={customPort}
+              onChange={e => setCustomPort(e.target.value)}
+              placeholder="25565"
+            />
+          )}
+        </div>
+
+        {/* チェックボタン */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button
+            className="btn btn-start"
+            onClick={checkPort}
+            disabled={checking || !resolvedPort || !ip.trim()}
+            style={{ fontSize: 12 }}
+          >
+            {checking ? '確認中...' : '🔍 開放チェック'}
+          </button>
+          {resolvedPort && ip && (
+            <span style={{ fontSize: 12, color: 'var(--text-dim)' }}>
+              {ip}:{resolvedPort}
+            </span>
+          )}
+        </div>
+
+        {/* 結果 */}
+        {result && (
+          <div style={{
+            padding: '10px 14px', borderRadius: 8, fontSize: 13, fontWeight: 600,
+            background: result.success && result.reachable ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
+            border: `1px solid ${result.success && result.reachable ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.25)'}`,
+            color: result.success && result.reachable ? '#15803d' : '#b91c1c',
+          }}>
+            {!result.success
+              ? `⚠ チェック失敗: ${result.error}`
+              : result.reachable
+                ? `✅ ポート ${result.port} は外部から到達可能です`
+                : `❌ ポート ${result.port} は外部から到達できません（ファイアウォールまたはルーターの設定を確認してください）`
+            }
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── 回線速度計測セクション ──────────────────────────────────────────────────
+function SpeedSection() {
+  const [status, setStatus] = useState('idle') // 'idle' | 'running' | 'done' | 'error'
+  const [result, setResult] = useState(null)
+
+  const measure = async () => {
+    setStatus('running')
+    setResult(null)
+    const res = await window.api.checkInternetSpeed()
+    setResult(res)
+    setStatus(res.success ? 'done' : 'error')
+  }
+
+  const speedColor = (mbps) => {
+    if (mbps >= 100) return '#22c55e'
+    if (mbps >= 30) return '#eab308'
+    return '#ef4444'
+  }
+
+  return (
+    <div className="diag-card">
+      <div className="diag-card-title">📡 回線速度</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <button
+          className="btn btn-restart"
+          onClick={measure}
+          disabled={status === 'running'}
+          style={{ fontSize: 12 }}
+        >
+          {status === 'running' ? '計測中...' : '⚡ 速度を計測'}
+        </button>
+        {status === 'running' && (
+          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>約30秒かかる場合があります</span>
+        )}
+        {status === 'done' && result?.success && (
+          <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+            <span style={{ fontSize: 22, fontWeight: 700, color: speedColor(result.mbps) }}>
+              {result.mbps} <span style={{ fontSize: 14 }}>Mbps</span>
+            </span>
+            <span style={{ fontSize: 12, color: 'var(--text-dim)' }}>
+              {(result.bytes / 1_000_000).toFixed(1)} MB / {result.elapsed}s
+            </span>
+          </div>
+        )}
+        {status === 'error' && (
+          <span style={{ fontSize: 13, color: '#ef4444' }}>⚠ 計測失敗: {result?.error}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export default function Diagnostics() {
   const [baseDir, setBaseDir]         = useState('')
   const [dbInstalled, setDbInstalled] = useState(false)
   const [dbRunning, setDbRunning]     = useState(false)
   const [localIp, setLocalIp]         = useState('')
   const [globalIp, setGlobalIp]       = useState('')
+  const [allPorts, setAllPorts]       = useState(null)
 
-  // UPnP 可用性
-  const [upnpSig, setUpnpSig]     = useState(STATUS.IDLE)
+  const [upnpSig, setUpnpSig]       = useState(STATUS.IDLE)
   const [upnpDetail, setUpnpDetail] = useState('')
 
-  // チェック判定
-  const checks = [
-    baseDir !== '',
-    dbInstalled && dbRunning,
-    localIp !== '' && localIp !== '取得失敗',
-    globalIp !== '' && globalIp !== '取得失敗',
-    upnpSig === STATUS.OK,
-  ]
-  const passCount = checks.filter(Boolean).length
-  const allOk     = checks.every(Boolean)
+  const baseDirSig = baseDir ? STATUS.OK : STATUS.ERROR
+  const dbSig      = !dbInstalled ? STATUS.ERROR : dbRunning ? STATUS.OK : STATUS.WARN
+  const localSig   = localIp && localIp !== '取得失敗' ? STATUS.OK : STATUS.ERROR
+  const globalSig  = globalIp && globalIp !== '取得失敗' ? STATUS.OK : STATUS.ERROR
+
+  const checks = [baseDirSig, dbSig, localSig, globalSig, upnpSig].map(s => s === STATUS.OK || s === STATUS.WARN)
+  const errorChecks = [baseDirSig, dbSig, localSig, globalSig, upnpSig].filter(s => s === STATUS.ERROR).length
+  const allOk = errorChecks === 0 && upnpSig !== STATUS.IDLE && upnpSig !== STATUS.LOADING
 
   const load = useCallback(async () => {
     const s = await window.api.loadSettings()
@@ -62,8 +240,9 @@ export default function Diagnostics() {
     setLocalIp(lip)
     const gip = await window.api.fetchGlobalIp()
     setGlobalIp(gip)
+    const ports = await window.api.getAllServerPorts()
+    setAllPorts(ports)
 
-    // UPnP チェック
     setUpnpSig(STATUS.LOADING)
     setUpnpDetail('')
     const upnp = await window.api.diagUpnpCheck()
@@ -82,32 +261,37 @@ export default function Diagnostics() {
     return () => unsub()
   }, [load])
 
-  const baseDirSig = baseDir ? STATUS.OK : STATUS.ERROR
-  const dbSig      = !dbInstalled ? STATUS.ERROR : dbRunning ? STATUS.OK : STATUS.WARN
-  const localSig   = localIp && localIp !== '取得失敗' ? STATUS.OK : STATUS.ERROR
-  const globalSig  = globalIp && globalIp !== '取得失敗' ? STATUS.OK : STATUS.ERROR
-
   return (
     <div className="diag-root">
       <h2 className="diag-title">🔍 ネットワーク診断</h2>
 
+      {/* チェック項目 */}
       <div className="diag-card">
-        <div className="diag-card-title">📋 チェック項目</div>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+          <div className="diag-card-title" style={{ margin: 0 }}>📋 チェック項目</div>
+          <button className="btn btn-restart" style={{ fontSize: 12 }} onClick={load}>🔄 再チェック</button>
+        </div>
         <div className="diag-signals">
           <Signal status={baseDirSig} label="ベースディレクトリ">
-            <span className="diag-signal-value">{baseDir || '未設定'}</span>
+            <span className="diag-signal-value" style={{ color: baseDirSig === STATUS.ERROR ? '#ef4444' : undefined }}>
+              {baseDir || '未設定'}
+            </span>
           </Signal>
           <Signal status={dbSig} label="データベース (MariaDB)">
-            <span className="diag-signal-value">
+            <span className="diag-signal-value" style={{ color: dbSig === STATUS.ERROR ? '#ef4444' : undefined }}>
               {!dbInstalled ? '未インストール' : dbRunning ? '稼働中' : 'インストール済み・停止中'}
             </span>
           </Signal>
           <Signal status={localSig} label="ローカル IP">
-            <span className="diag-signal-value">{localIp || '取得中...'}</span>
+            <span className="diag-signal-value" style={{ color: localSig === STATUS.ERROR ? '#ef4444' : undefined }}>
+              {localIp || '取得中...'}
+            </span>
             {localIp && localIp !== '取得失敗' && <CopyBtn text={localIp} />}
           </Signal>
           <Signal status={globalSig} label="グローバル IP">
-            <span className="diag-signal-value">{globalIp || '取得中...'}</span>
+            <span className="diag-signal-value" style={{ color: globalSig === STATUS.ERROR ? '#ef4444' : undefined }}>
+              {globalIp || '取得中...'}
+            </span>
             {globalIp && globalIp !== '取得失敗' && <CopyBtn text={globalIp} />}
           </Signal>
           <Signal status={upnpSig} label="UPnP">
@@ -120,9 +304,17 @@ export default function Diagnostics() {
         <div className={`diag-summary ${allOk ? 'diag-summary--ok' : 'diag-summary--ng'}`}>
           {allOk
             ? '✅ チェック完了'
-            : <span>❌ 不足: <strong style={{ color: '#ef4444' }}>{checks.length - passCount}</strong> 項目</span>}
+            : errorChecks > 0
+              ? <span>❌ 不足: <strong style={{ color: '#ef4444' }}>{errorChecks}</strong> 件</span>
+              : '⚠ 一部確認が必要です'}
         </div>
       </div>
+
+      {/* 回線速度 */}
+      <SpeedSection />
+
+      {/* ポート開放チェック */}
+      <PortCheckSection globalIp={globalIp} allPorts={allPorts} />
     </div>
   )
 }

--- a/src/renderer/src/components/ServerList.jsx
+++ b/src/renderer/src/components/ServerList.jsx
@@ -293,12 +293,18 @@ function PropertiesEditor({ properties, onChange, clusterOnly = false, lockedKey
 }
 
 
-function ConfirmModal({ message, onConfirm, onClose, confirmLabel = '削除', confirmClass = 'btn-stop' }) {
+function ConfirmModal({ message, onConfirm, onClose, confirmLabel = '削除', confirmClass = 'btn-stop', checkboxLabel, checkboxChecked, onCheckboxChange }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
         <div className="modal-title">確認</div>
-        <p style={{ color: 'var(--text-2)', fontSize: 14 }}>{message}</p>
+        <p style={{ color: 'var(--text-2)', fontSize: 14, whiteSpace: 'pre-wrap' }}>{message}</p>
+        {checkboxLabel && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#ef4444', marginBottom: 12, cursor: 'pointer' }}>
+            <input type="checkbox" checked={!!checkboxChecked} onChange={e => onCheckboxChange && onCheckboxChange(e.target.checked)} />
+            {checkboxLabel}
+          </label>
+        )}
         <div className="modal-actions">
           <button className={`btn ${confirmClass}`} onClick={onConfirm}>{confirmLabel}</button>
           <button className="btn btn-restart" onClick={onClose}>キャンセル</button>
@@ -849,11 +855,18 @@ function ClusterConsole({ cluster, serverLogs, velocityLogs, serverStatuses }) {
             onClick={() => setConsoleTab(s.id)}>{s.name}</button>
         ))}
       </div>
-      <div className="log-box" ref={logRef} style={{ height: 380 }}>
-        {currentLogs.length === 0
-          ? <span style={{ color: 'var(--text-dim)' }}>ログなし</span>
-          : currentLogs.map((l, i) => <div key={i}>{l}</div>)
-        }
+      <div style={{ position: 'relative' }}>
+        <div className="log-box" ref={logRef} style={{ height: 380 }}>
+          {currentLogs.length === 0
+            ? <span style={{ color: 'var(--text-dim)' }}>ログなし</span>
+            : currentLogs.map((l, i) => <div key={i}>{l}</div>)
+          }
+        </div>
+        <button
+          style={{ position: 'absolute', top: 6, right: 6, background: 'rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.12)', color: '#8ab4c8', fontSize: 11, padding: '2px 8px', borderRadius: 4, cursor: 'pointer' }}
+          onClick={() => navigator.clipboard.writeText(currentLogs.join('\n'))}
+          title="ログをコピー"
+        >📋</button>
       </div>
       {consoleTab !== 'velocity' && serverStatuses[consoleTab] === 'running' && (
         <input className="modal-input" style={{ marginTop: 8, width: '100%' }}
@@ -987,6 +1000,7 @@ function statusDotClass(s) {
 
 function ServerCard({ server, onClick, onDelete, onUpdatePort, onStart, onStop, onRestart, serverStatus, conflictInfo }) {
   const [showConfirm, setShowConfirm] = useState(false)
+  const [deleteFiles, setDeleteFiles] = useState(false)
   const [editingPort, setEditingPort] = useState(false)
   const [portValue, setPortValue] = useState(String(server.port))
 
@@ -1046,8 +1060,11 @@ function ServerCard({ server, onClick, onDelete, onUpdatePort, onStart, onStop, 
       {showConfirm && (
         <ConfirmModal
           message={`「${server.name}」を削除しますか？`}
-          onConfirm={() => { setShowConfirm(false); onDelete() }}
-          onClose={() => setShowConfirm(false)}
+          onConfirm={() => { setShowConfirm(false); onDelete(deleteFiles) }}
+          onClose={() => { setShowConfirm(false); setDeleteFiles(false) }}
+          checkboxLabel="実ファイルも削除する（元に戻せません）"
+          checkboxChecked={deleteFiles}
+          onCheckboxChange={setDeleteFiles}
         />
       )}
     </div>
@@ -1193,13 +1210,23 @@ function ServerDetail({ server, cluster, onBack, onUpdateServer, serverStatus, o
         {server.type === 'paper' && (
           <button className={`tab-btn ${subTab === 'plugins' ? 'active' : ''}`} onClick={() => setSubTab('plugins')}>Plugin</button>
         )}
+        {cluster && (server.type || 'fabric') === 'fabric' && (
+          <button className={`tab-btn ${subTab === 'shared' ? 'active' : ''}`} onClick={() => setSubTab('shared')}>🔗 共有設定</button>
+        )}
       </div>
 
       <div className="tab-content">
         {subTab === 'log' && (
           <div>
-            <div className="log-box" ref={logRef} style={{ height: 400 }}>
-              {logs.length === 0 ? <span style={{ color: 'var(--text-dim)' }}>ログなし</span> : logs.map((l, i) => <div key={i}>{l}</div>)}
+            <div style={{ position: 'relative' }}>
+              <div className="log-box" ref={logRef} style={{ height: 400 }}>
+                {logs.length === 0 ? <span style={{ color: 'var(--text-dim)' }}>ログなし</span> : logs.map((l, i) => <div key={i}>{l}</div>)}
+              </div>
+              <button
+                style={{ position: 'absolute', top: 6, right: 6, background: 'rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.12)', color: '#8ab4c8', fontSize: 11, padding: '2px 8px', borderRadius: 4, cursor: 'pointer' }}
+                onClick={() => navigator.clipboard.writeText(logs.join('\n'))}
+                title="ログをコピー"
+              >📋</button>
             </div>
             {serverStatus === 'running' && (
               <input className="modal-input" style={{ marginTop: 8, width: '100%' }} placeholder="コマンドを入力してEnter"
@@ -1303,6 +1330,9 @@ function ServerDetail({ server, cluster, onBack, onUpdateServer, serverStatus, o
         )}
         {(subTab === 'mods' || subTab === 'plugins') && (
           <ModPluginTab server={server} cluster={cluster} onUpdateServer={onUpdateServer} />
+        )}
+        {subTab === 'shared' && cluster && (
+          <InvsyncTab server={server} />
         )}
       </div>
       {showWorldDeleteConfirm1 && (
@@ -1923,6 +1953,251 @@ function VelocityPluginTab({ cluster, settings, onUpdateCluster }) {
   )
 }
 
+// ─── 必須Mod 警告モーダル ────────────────────────────────────────────────────
+function RequiredModsWarnModal({ server, cluster, missing, onRepairAndStart, onStartAnyway, onClose }) {
+  const [repairing, setRepairing] = useState(false)
+  const handleRepair = async () => {
+    setRepairing(true)
+    await onRepairAndStart()
+    setRepairing(false)
+  }
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-title">⚠ 必須Modが見つかりません</div>
+        <p style={{ color: 'var(--text-2)', fontSize: 14, marginBottom: 8 }}>
+          {cluster ? `「${cluster.name}」クラスターの` : ''}「{server.name}」のmodsフォルダに以下のModが見つかりませんでした:
+        </p>
+        <ul style={{ margin: '0 0 14px 16px', padding: 0, color: '#ef4444', fontSize: 13 }}>
+          {missing.map(m => <li key={m}>{m}</li>)}
+        </ul>
+        <p style={{ color: 'var(--text-muted)', fontSize: 12, marginBottom: 14 }}>
+          これらのModはクラスター機能に必要です。再インストールしますか？
+        </p>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button className="btn btn-start" onClick={handleRepair} disabled={repairing}>
+            {repairing ? '修復中...' : '🔧 再インストールして起動'}
+          </button>
+          <button className="btn btn-restart" onClick={onStartAnyway} disabled={repairing}>
+            このまま起動
+          </button>
+          <button className="btn" onClick={onClose} disabled={repairing}
+            style={{ background: 'var(--border)', color: 'var(--text-2)' }}>
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Invsync 共有設定タブ ────────────────────────────────────────────────────
+function InvsyncTab({ server }) {
+  const [versions, setVersions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [selectedVersion, setSelectedVersion] = useState(null)
+  const [installing, setInstalling] = useState(false)
+  const [installResult, setInstallResult] = useState(null)
+  const [installed, setInstalled] = useState(null) // { installed, fileName }
+
+  useEffect(() => {
+    const init = async () => {
+      setLoading(true)
+      const [vers, status] = await Promise.all([
+        window.api.invsyncListVersions(),
+        server.serverDir ? window.api.invsyncCheck({ serverDir: server.serverDir }) : Promise.resolve({ installed: false })
+      ])
+      setVersions(vers)
+      setInstalled(status)
+      // デフォルト選択: サーバーのMCバージョンと一致するものがあれば選択
+      if (vers.length > 0) {
+        const match = vers.find(v => v.mcVersion === server.mcVersion) || vers[0]
+        setSelectedVersion(match.tag)
+      }
+      setLoading(false)
+    }
+    init()
+  }, [server.id])
+
+  const handleInstall = async () => {
+    if (!selectedVersion || !server.serverDir) return
+    const ver = versions.find(v => v.tag === selectedVersion)
+    if (!ver) return
+    setInstalling(true)
+    setInstallResult(null)
+    const res = await window.api.invsyncInstall({
+      serverDir: server.serverDir,
+      downloadUrl: ver.downloadUrl,
+      fileName: ver.fileName,
+    })
+    setInstallResult(res)
+    if (res.success) {
+      const status = await window.api.invsyncCheck({ serverDir: server.serverDir })
+      setInstalled(status)
+    }
+    setInstalling(false)
+  }
+
+  const isCompatible = (ver) => {
+    if (!server.mcVersion) return null
+    // バージョンが一致するか前方一致で判定
+    const mcVer = server.mcVersion.trim()
+    const modVer = ver.mcVersion.trim()
+    return modVer === mcVer || mcVer.startsWith(modVer) || modVer.startsWith(mcVer)
+  }
+
+  if (loading) return <div style={{ color: 'var(--text-muted)', padding: 16 }}>読み込み中...</div>
+
+  return (
+    <div style={{ padding: '16px 0', display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* 概要 */}
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10, padding: '14px 18px' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text)', marginBottom: 6 }}>インベントリ共有（Invsync）</div>
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.6 }}>
+          クラスター内のFabricサーバー間でインベントリを共有します。
+          同じクラスターのMariaDBに接続して、プレイヤーデータを同期します。
+        </div>
+      </div>
+
+      {/* インストール状態 */}
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10, padding: '14px 18px' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text)', marginBottom: 10 }}>インストール状態</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+          <span style={{
+            width: 10, height: 10, borderRadius: '50%', flexShrink: 0,
+            background: installed?.installed ? '#22c55e' : '#6b7280',
+          }} />
+          <span style={{ fontSize: 13, color: installed?.installed ? '#22c55e' : 'var(--text-muted)' }}>
+            {installed?.installed ? `インストール済み: ${installed.fileName}` : '未インストール'}
+          </span>
+        </div>
+
+        {/* バージョン選択 */}
+        {versions.length > 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 4 }}>バージョンを選択:</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 160, overflowY: 'auto' }}>
+              {versions.map(v => {
+                const compat = isCompatible(v)
+                return (
+                  <label key={v.tag} style={{
+                    display: 'flex', alignItems: 'center', gap: 10, padding: '7px 10px',
+                    borderRadius: 6, cursor: 'pointer',
+                    background: selectedVersion === v.tag ? 'rgba(var(--accent-rgb,99,102,241),0.1)' : 'var(--bg-section)',
+                    border: selectedVersion === v.tag ? '1px solid var(--text-accent)' : '1px solid transparent',
+                  }}>
+                    <input type="radio" name="invsync-ver" value={v.tag} checked={selectedVersion === v.tag}
+                      onChange={() => setSelectedVersion(v.tag)} />
+                    <span style={{ fontSize: 13, flex: 1, color: 'var(--text)' }}>{v.tag}</span>
+                    {compat !== null && (
+                      <span style={{
+                        fontSize: 11, padding: '2px 8px', borderRadius: 99, fontWeight: 600,
+                        background: compat ? 'rgba(34,197,94,0.12)' : 'rgba(239,68,68,0.1)',
+                        color: compat ? '#15803d' : '#b91c1c',
+                        border: `1px solid ${compat ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.2)'}`,
+                      }}>
+                        {compat ? '互換性あり' : '互換性なし'}
+                      </span>
+                    )}
+                  </label>
+                )
+              })}
+            </div>
+            <button
+              className="btn btn-start"
+              onClick={handleInstall}
+              disabled={installing || !selectedVersion || !server.serverDir}
+              style={{ marginTop: 8, fontSize: 12, alignSelf: 'flex-start' }}
+            >
+              {installing ? 'インストール中...' : '📥 インストール'}
+            </button>
+            {installResult && (
+              <div style={{ fontSize: 12, color: installResult.success ? '#22c55e' : '#ef4444', marginTop: 4 }}>
+                {installResult.success ? '✓ インストール完了' : `⚠ ${installResult.error}`}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div style={{ fontSize: 12, color: '#f59e0b' }}>
+            ⚠ バージョン一覧を取得できませんでした。インターネット接続を確認してください。
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── クラスター DB タブ ──────────────────────────────────────────────────────
+function ClusterDbTab({ cluster, dbRunning }) {
+  const schemaName = `${cluster.name.replace(/[^a-zA-Z0-9_]/g, '_')}_DB`
+  const [creating, setCreating] = useState(false)
+  const [createResult, setCreateResult] = useState(null)
+
+  const createSchema = async () => {
+    setCreating(true)
+    setCreateResult(null)
+    const res = await window.api.dbCreateSchema({ clusterName: cluster.name })
+    setCreateResult(res)
+    setCreating(false)
+  }
+
+  return (
+    <div style={{ padding: '16px 0', display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* グローバルDB状態 */}
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10, padding: '14px 18px' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text)', marginBottom: 10 }}>データベース接続状態</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{
+            width: 10, height: 10, borderRadius: '50%',
+            background: dbRunning ? '#22c55e' : '#ef4444',
+            boxShadow: dbRunning ? '0 0 6px #22c55e' : '0 0 6px #ef4444',
+            flexShrink: 0
+          }} />
+          <span style={{ fontSize: 13, color: dbRunning ? '#22c55e' : '#ef4444', fontWeight: 600 }}>
+            {dbRunning ? 'MariaDB 稼働中' : 'MariaDB 停止中'}
+          </span>
+        </div>
+        {!dbRunning && (
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-muted)' }}>
+            DBを使用するには、設定 &gt; SQL/DB タブから MariaDB を起動してください。
+          </div>
+        )}
+      </div>
+
+      {/* クラスター用スキーマ */}
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10, padding: '14px 18px' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text)', marginBottom: 10 }}>クラスター専用スキーマ</div>
+        <div style={{ display: 'flex', gap: 16, fontSize: 12, marginBottom: 8 }}>
+          <span style={{ minWidth: 80, color: 'var(--text-muted)', fontWeight: 600 }}>スキーマ名</span>
+          <code style={{ color: 'var(--text)', fontFamily: 'monospace' }}>{schemaName}</code>
+        </div>
+        <div style={{ display: 'flex', gap: 16, fontSize: 12, marginBottom: 12 }}>
+          <span style={{ minWidth: 80, color: 'var(--text-muted)', fontWeight: 600 }}>用途</span>
+          <span style={{ color: 'var(--text-muted)' }}>Invsync によるクラスター内インベントリ共有</span>
+        </div>
+        <button
+          className="btn btn-restart"
+          onClick={createSchema}
+          disabled={!dbRunning || creating}
+          style={{ fontSize: 12 }}
+        >
+          {creating ? '作成中...' : '🔄 スキーマを作成/確認'}
+        </button>
+        {createResult && (
+          <div style={{ marginTop: 8, fontSize: 12, color: createResult.success ? '#22c55e' : '#ef4444' }}>
+            {createResult.success ? '✓ スキーマを確認しました' : `⚠ ${createResult.error}`}
+          </div>
+        )}
+        {!dbRunning && (
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-dim)' }}>
+            ※ MariaDB が起動しているときはクラスター作成時に自動生成されます
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function ServerList() {
   const [data, setData] = useState(null)
   const [settings, setSettings] = useState({ baseDir: '' })
@@ -1935,9 +2210,12 @@ function ServerList() {
   const [showAddCluster, setShowAddCluster] = useState(false)
   const [deleteClusterConfirm, setDeleteClusterConfirm] = useState(null)
   const [deleteClusterConfirm2, setDeleteClusterConfirm2] = useState(null)
+  const [deleteClusterFiles, setDeleteClusterFiles] = useState(false)
+  const [requiredModsWarn, setRequiredModsWarn] = useState(null) // { server, cluster, missing, pendingStart }
   const [serverStatuses, setServerStatuses] = useState({})
   const [velocityStatuses, setVelocityStatuses] = useState({})
   const [velocityWarn, setVelocityWarn] = useState(null)
+  const [dbRunning, setDbRunning] = useState(false)
   const [showImport, setShowImport] = useState(false)
   const [serverLogs, setServerLogs] = useState({})
   const [velocityLogs, setVelocityLogs] = useState({})
@@ -1952,6 +2230,9 @@ function ServerList() {
     })
     window.api.loadSettings().then(s => setSettings(s))
     window.api.fetchGlobalIp().then(ip => setGlobalIp(ip))
+    window.api.dbStatus().then(s => setDbRunning(s.running))
+    const unsubDb = window.api.onDbStatusChanged(info => setDbRunning(info.running))
+    return () => unsubDb()
   }, [])
 
   useEffect(() => {
@@ -2006,7 +2287,7 @@ function ServerList() {
     })
   }
 
-  const startServer = async (server) => {
+  const doStartServer = async (server) => {
     if (!server.serverDir) return
     setStatus(server.id, 'starting')
     setServerLogs(prev => { const n = { ...prev }; delete n[server.id]; return n })
@@ -2018,6 +2299,21 @@ function ServerList() {
       javaPath: server.javaPath || null
     })
     if (!ok) setStatus(server.id, null)
+  }
+
+  const startServer = async (server) => {
+    if (!server.serverDir) return
+    // クラスター配下のFabricサーバーは起動前に必須Modをチェック
+    const inCluster = data?.clusters?.some(c => c.servers?.some(s => s.id === server.id))
+    if (inCluster && (server.type || 'fabric') === 'fabric') {
+      const check = await window.api.checkRequiredMods({ serverDir: server.serverDir, isCluster: true })
+      if (!check.ok) {
+        const cluster = data.clusters.find(c => c.servers.some(s => s.id === server.id))
+        setRequiredModsWarn({ server, cluster, missing: check.missing })
+        return
+      }
+    }
+    await doStartServer(server)
   }
 
   const stopServer = async (server) => {
@@ -2083,8 +2379,15 @@ function ServerList() {
     save(newData)
   }
 
-  const deleteServer = (clusterId, serverId) => {
+  const deleteServer = (clusterId, serverId, deleteFiles = false) => {
     if (serverStatuses[serverId]) return
+    const allServers = clusterId === 'standalone'
+      ? data.standalone
+      : (data.clusters.find(c => c.id === clusterId)?.servers || [])
+    const srv = allServers.find(s => s.id === serverId)
+    if (deleteFiles && srv?.serverDir) {
+      window.api.deleteServerDir({ serverDir: srv.serverDir }).catch(() => {})
+    }
     const newData = clusterId === 'standalone'
       ? { ...data, standalone: data.standalone.filter(s => s.id !== serverId) }
       : { ...data, clusters: data.clusters.map(c => c.id === clusterId ? { ...c, servers: c.servers.filter(s => s.id !== serverId) } : c) }
@@ -2144,9 +2447,13 @@ function ServerList() {
       })
   }
 
-  const deleteCluster = (clusterId) => {
+  const deleteCluster = (clusterId, deleteFiles = false) => {
     const cluster = data.clusters.find(c => c.id === clusterId)
     if (cluster?.servers.some(s => serverStatuses[s.id])) return
+    if (deleteFiles && settings.baseDir && cluster?.name) {
+      const clusterDir = `${settings.baseDir}\\${cluster.name}`
+      window.api.deleteClusterDir({ clusterDir }).catch(() => {})
+    }
     const newClusters = data.clusters.filter(c => c.id !== clusterId)
     if (activeTab === clusterId) setActiveTab(newClusters.length > 0 ? newClusters[0].id : 'standalone')
     save({ ...data, clusters: newClusters })
@@ -2193,6 +2500,13 @@ function ServerList() {
     save({ ...data, clusters: data.clusters.map(c => c.id === cluster.id ? updatedCluster : c) })
   }
 
+  const syncLevelName = (serverDir, serverName, levelName) => {
+    // level-name が "world"（デフォルト）の場合はサーバー名を level-name に書き込む
+    if (levelName === 'world' || !levelName) {
+      window.api.writeServerProperties({ serverDir, properties: { 'level-name': serverName } }).catch(() => {})
+    }
+  }
+
   const importCluster = (scanResult) => {
     const velocityConfig = scanResult.velocityConfig || {
       port: 25577,
@@ -2219,6 +2533,10 @@ function ServerList() {
       defaultProperties: { ...DEFAULT_CLUSTER_PROPERTIES },
       velocity: velocityConfig,
     }
+    // level-name とサーバー名を同期
+    for (const s of scanResult.servers) {
+      if (s.serverDir) syncLevelName(s.serverDir, s.name, s.levelName)
+    }
     save({ ...data, clusters: [...data.clusters, cluster] })
     setActiveTab(cluster.id)
   }
@@ -2235,6 +2553,8 @@ function ServerList() {
       jvmMemory: { value: 2, unit: 'G' },
       individualProperties: null,
     }
+    // level-name とサーバー名を同期
+    if (scanResult.serverDir) syncLevelName(scanResult.serverDir, scanResult.name, scanResult.levelName)
     save({ ...data, standalone: [...data.standalone, server] })
     setActiveTab('standalone')
   }
@@ -2349,6 +2669,10 @@ function ServerList() {
                 <button className={`tab-btn ${clusterSubTab === 'mods' ? 'active' : ''}`} onClick={() => setClusterSubTab('mods')}>Mod</button>
                 <button className={`tab-btn ${clusterSubTab === 'plugins' ? 'active' : ''}`} onClick={() => setClusterSubTab('plugins')}>Plugins</button>
                 <button className={`tab-btn ${clusterSubTab === 'players' ? 'active' : ''}`} onClick={() => setClusterSubTab('players')}>プレイヤー</button>
+                <button className={`tab-btn ${clusterSubTab === 'db' ? 'active' : ''}`} onClick={() => setClusterSubTab('db')}>
+                  🗄 DB
+                  <span style={{ marginLeft: 4, width: 7, height: 7, borderRadius: '50%', background: dbRunning ? '#22c55e' : '#ef4444', display: 'inline-block', verticalAlign: 'middle' }} />
+                </button>
               </div>
             </div>
 
@@ -2362,7 +2686,7 @@ function ServerList() {
                   >
                     <ServerCard server={s}
                       onClick={() => { setSelectedServer(s); setSelectedCluster(activeCluster) }}
-                      onDelete={() => deleteServer(activeCluster.id, s.id)}
+                      onDelete={(deleteFiles) => deleteServer(activeCluster.id, s.id, deleteFiles)}
                       onUpdatePort={(port) => updatePort(activeCluster.id, s.id, port)}
                       serverStatus={serverStatuses[s.id] || null}
                       onStart={() => startServer(s)} onStop={() => stopServer(s)} onRestart={() => restartServer(s)}
@@ -2408,6 +2732,9 @@ function ServerList() {
                 onSendCommand={(serverId, cmd) => window.api.sendCommand({ serverId, command: cmd })}
               />
             )}
+            {clusterSubTab === 'db' && (
+              <ClusterDbTab cluster={activeCluster} dbRunning={dbRunning} />
+            )}
           </>
         )}
 
@@ -2426,7 +2753,7 @@ function ServerList() {
                 >
                   <ServerCard server={s}
                     onClick={() => { setSelectedServer(s); setSelectedCluster(null) }}
-                    onDelete={() => deleteServer('standalone', s.id)}
+                    onDelete={(deleteFiles) => deleteServer('standalone', s.id, deleteFiles)}
                     onUpdatePort={(port) => updatePort('standalone', s.id, port)}
                     serverStatus={serverStatuses[s.id] || null}
                     onStart={() => startServer(s)} onStop={() => stopServer(s)} onRestart={() => restartServer(s)}
@@ -2444,14 +2771,17 @@ function ServerList() {
         <ConfirmModal
           message={`「${deleteClusterConfirm.name}」を削除しますか？\n中のサーバーも全て削除されます。`}
           onConfirm={() => { setDeleteClusterConfirm2(deleteClusterConfirm); setDeleteClusterConfirm(null) }}
-          onClose={() => setDeleteClusterConfirm(null)}
+          onClose={() => { setDeleteClusterConfirm(null); setDeleteClusterFiles(false) }}
+          checkboxLabel="実ファイルも削除する（元に戻せません）"
+          checkboxChecked={deleteClusterFiles}
+          onCheckboxChange={setDeleteClusterFiles}
         />
       )}
       {deleteClusterConfirm2 && (
         <ConfirmModal
-          message={`本当に削除しますか？この操作は取り消せません。`}
-          onConfirm={() => { deleteCluster(deleteClusterConfirm2.id); setDeleteClusterConfirm2(null) }}
-          onClose={() => setDeleteClusterConfirm2(null)}
+          message={`本当に削除しますか？この操作は取り消せません。${deleteClusterFiles ? '\n\n⚠ 実ファイルも完全に削除されます。' : ''}`}
+          onConfirm={() => { deleteCluster(deleteClusterConfirm2.id, deleteClusterFiles); setDeleteClusterConfirm2(null); setDeleteClusterFiles(false) }}
+          onClose={() => { setDeleteClusterConfirm2(null); setDeleteClusterFiles(false) }}
         />
       )}
       {velocityWarn && (
@@ -2474,6 +2804,28 @@ function ServerList() {
           onClose={() => setShowImport(false)}
           onImportCluster={importCluster}
           onImportStandalone={importStandalone}
+        />
+      )}
+
+      {/* 必須Mod不足の警告ダイアログ */}
+      {requiredModsWarn && (
+        <RequiredModsWarnModal
+          server={requiredModsWarn.server}
+          cluster={requiredModsWarn.cluster}
+          missing={requiredModsWarn.missing}
+          onRepairAndStart={async () => {
+            const { server, cluster } = requiredModsWarn
+            setRequiredModsWarn(null)
+            await window.api.repairRequiredMods({
+              serverDir: server.serverDir,
+              mcVersion: server.mcVersion,
+              forwardingSecret: cluster?.velocity?.forwardingSecret || '',
+              missingMods: requiredModsWarn.missing,
+            })
+            await doStartServer(server)
+          }}
+          onStartAnyway={() => { const s = requiredModsWarn.server; setRequiredModsWarn(null); doStartServer(s) }}
+          onClose={() => setRequiredModsWarn(null)}
         />
       )}
     </div>

--- a/src/renderer/src/components/Settings.jsx
+++ b/src/renderer/src/components/Settings.jsx
@@ -235,7 +235,7 @@ function DbSection({ baseDir }) {
   }, [load])
 
   const startInstall = async () => {
-    if (!baseDir) return alert('先にベースディレクトリを設定してください')
+    if (!baseDir) return
     const pass = dbPassword.trim() || Math.random().toString(36).slice(2, 12)
     setDbInstallLog([]); setDbInstallPct(0); setDbInstalling(true); setDbPassword(pass)
     await window.api.dbInstall({ baseDir, password: pass })
@@ -251,10 +251,19 @@ function DbSection({ baseDir }) {
     } else alert(`削除失敗: ${res.error}`)
   }
 
+  const baseDirMissing = !baseDir
+
   return (
     <div className="settings-section">
       <div className="settings-label" style={{ marginBottom: 2 }}>🗄 MariaDB 管理</div>
       <div className="settings-description">クラスター間データ連携（Invsync）に使用するデータベース</div>
+
+      {/* ベースdir未設定の警告 */}
+      {baseDirMissing && (
+        <div style={{ marginTop: 10, padding: '10px 14px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)', fontSize: 12, color: '#b91c1c' }}>
+          ⚠ DBをインストールする前に「サーバーベースフォルダ」を設定してください。
+        </div>
+      )}
 
       {!dbInstalled ? (
         <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -265,13 +274,21 @@ function DbSection({ baseDir }) {
             <span style={{ fontSize: 13, color: 'var(--text-2)', minWidth: 90 }}>パスワード</span>
             <input className="modal-input" style={{ width: 200 }} type="text"
               placeholder="空欄で自動生成" value={dbPassword}
-              onChange={e => setDbPassword(e.target.value)} />
-            <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>⚠ 設定後変更不可</span>
+              onChange={e => setDbPassword(e.target.value)}
+              disabled={baseDirMissing} />
+          </div>
+          <div style={{ padding: '8px 12px', borderRadius: 6, background: 'rgba(251,191,36,0.08)', border: '1px solid rgba(251,191,36,0.2)', fontSize: 12, color: '#92400e' }}>
+            ⚠ パスワードはDBインストール後に変更できません。空欄の場合は自動生成されます。
           </div>
           <div>
-            <button className="btn btn-start" onClick={startInstall} disabled={dbInstalling || !baseDir}>
+            <button className="btn btn-start" onClick={startInstall} disabled={dbInstalling || baseDirMissing}>
               {dbInstalling ? 'インストール中...' : '📥 MariaDB をインストール'}
             </button>
+            {baseDirMissing && (
+              <span style={{ marginLeft: 10, fontSize: 12, color: '#ef4444' }}>
+                ※ ベースフォルダを設定してから実行してください
+              </span>
+            )}
           </div>
           {dbInstalling && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
@@ -367,9 +384,9 @@ function PortRow({ label, port, state, onOpen, onClose }) {
 }
 
 function PortSection() {
-  const [allPorts, setAllPorts]       = useState(null)   // { clusters, standalone }
-  const [mappedPorts, setMappedPorts] = useState([])     // UPnP で開いてるポート番号の配列
-  const [portStates, setPortStates]   = useState({})     // { port: PORT_STATE }
+  const [allPorts, setAllPorts]       = useState(null)
+  const [mappedPorts, setMappedPorts] = useState([])
+  const [portStates, setPortStates]   = useState({})
   const [loadingMapped, setLoadingMapped] = useState(false)
 
   const loadPorts = useCallback(async () => {
@@ -383,7 +400,6 @@ function PortSection() {
     const mapped = await window.api.diagUpnpListMapped()
     const openNums = mapped.map(m => m.port)
     setMappedPorts(openNums)
-    // ポート状態を一括更新
     setPortStates(prev => {
       const next = { ...prev }
       const src = portsData || allPorts
@@ -402,7 +418,6 @@ function PortSection() {
     loadPorts().then(d => loadMapped(d))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // フラットなポート一覧 { key, label, port, group }
   const getFlatPorts = (d) => {
     const ports = []
     for (const cluster of d?.clusters || []) {
@@ -478,14 +493,12 @@ function PortSection() {
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginTop: 12 }}>
-          {/* クラスター */}
           {clusterPorts.length > 0 && (
             <div>
               <div className="port-group-title">🔗 クラスター</div>
               <div className="port-list">{renderRows(clusterPorts)}</div>
             </div>
           )}
-          {/* スタンドアロン */}
           {standalonePorts.length > 0 && (
             <div>
               <div className="port-group-title">🖥 スタンドアロン</div>
@@ -512,9 +525,32 @@ function FolderRow({ label, description, value, onSelect }) {
   )
 }
 
+// ─── サブタブボタン ────────────────────────────────────────────────────────
+function SubTab({ active, onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: '6px 18px',
+        borderRadius: 8,
+        border: active ? '1px solid var(--text-accent)' : '1px solid var(--border)',
+        background: active ? 'rgba(var(--accent-rgb, 99,102,241),0.12)' : 'var(--bg-card)',
+        color: active ? 'var(--text-accent)' : 'var(--text-muted)',
+        fontWeight: active ? 700 : 400,
+        fontSize: 13,
+        cursor: 'pointer',
+        transition: 'all 0.15s',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
 // ─── メインコンポーネント ────────────────────────────────────────────────────
 function Settings() {
   const [baseDir, setBaseDir] = useState('')
+  const [subTab, setSubTab] = useState('java')
 
   useEffect(() => {
     window.api.loadSettings().then(s => setBaseDir(s.baseDir || ''))
@@ -536,9 +572,17 @@ function Settings() {
         value={baseDir}
         onSelect={pick}
       />
-      <JavaSection />
-      <DbSection baseDir={baseDir} />
-      <PortSection />
+
+      {/* サブタブ */}
+      <div style={{ display: 'flex', gap: 8, padding: '4px 0 12px 0', borderBottom: '1px solid var(--border)', marginBottom: 4 }}>
+        <SubTab active={subTab === 'java'} onClick={() => setSubTab('java')}>☕ Java管理</SubTab>
+        <SubTab active={subTab === 'db'} onClick={() => setSubTab('db')}>🗄 SQL / DB</SubTab>
+        <SubTab active={subTab === 'port'} onClick={() => setSubTab('port')}>🔓 ポート管理</SubTab>
+      </div>
+
+      {subTab === 'java' && <JavaSection />}
+      {subTab === 'db'   && <DbSection baseDir={baseDir} />}
+      {subTab === 'port' && <PortSection />}
     </div>
   )
 }


### PR DESCRIPTION
## 設定タブ
- サブタブ化 [Java管理 / SQL・DB / ポート管理]
- DBインストール前にベースフォルダ必須の明示
- パスワード変更不可の注意書き追加

## SQL / DB 関連
- アプリ起動時にMariaDBを自動起動（インストール済みの場合）
- クラスター配下のFabricサーバー起動中のみ終了ガード有効
  - ダイアログに「クラスターXXのサーバーYYが起動中」と表示
- クラスタータブに🗄DBタブ追加（スキーマ状態・作成ボタン）
- delete-cluster-dir IPC ハンドラ追加

## 共有設定（Invsync）
- Fabricクラスターサーバーのみ「共有設定」タブを表示
- Invsync バージョン一覧取得・インストール（GitHub Releases）
- MCバージョンとの互換性表示（互換性あり/なし）

## ClusterConnect / FabricAPI チェック
- クラスターFabricサーバー起動前に必須Modをチェック
- 不足の場合は警告ダイアログ「再インストールして起動/このまま起動/キャンセル」
- invsync-list-versions / invsync-install / invsync-check IPC追加

## 診断タブ
- 回線速度計測セクション追加（Cloudflare経由でMbps計測）
- ポート開放チェックセクション追加
  - クラスター/スタンドアロン一覧から選択 or 手動ポート入力
  - IPアドレス入力欄（グローバルIPデフォルト・リセットボタン）
- 不足項目を赤色でハイライト、サマリーに件数表示
- check-internet-speed / diagCheckPortExternal IPC追加

## コンソール
- 全ログボックスにコピーボタン追加（📋）
- Java起動時にJAVA_TOOL_OPTIONS環境変数を設定して文字化け防止

## サーバー名 = ワールド名
- scan-server-dir / scan-cluster-dir で level-name を読み取り
- level-name が "world"（デフォルト）以外はそれをサーバー名として使用
- インポート時に level-name をサーバー名と同期

## 削除オプション
- ServerCard（ホスト削除）にチェックボックス追加「実ファイルも削除する」
- クラスター削除ダイアログにも同様のチェックボックス追加
- deleteCluster / deleteServer が deleteFiles フラグを受け取るよう変更

https://claude.ai/code/session_013uCfAamWEf1R23APEbbEdu